### PR TITLE
fix order of reset and enable

### DIFF
--- a/src/EvtListener.cpp
+++ b/src/EvtListener.cpp
@@ -21,8 +21,8 @@ void EvtListener::disable()
 
 void EvtListener::enable()
 {
-  _enabled = true;
   reset();
+  _enabled = true;
 }
 
 EvtListener::~EvtListener()


### PR DESCRIPTION
In a certain environment I want to disable the event by default. So I set `_enable = false` in my `reset()` function.

```
void EvtOnceListener::reset() {
  disable();
}
```
The current order in the default `enable()` function prevents to enable the event for ever. This PR fixes this.