### PR TITLE
fixed listener queue memory overflow

### DIFF
--- a/src/EvtContext.cpp
+++ b/src/EvtContext.cpp
@@ -44,7 +44,7 @@ void EvtContext::reset()
     _listenerCount = 0;
 }
 
-void EvtContext::addListener(IEvtListener *lstn)
+bool EvtContext::addListener(IEvtListener *lstn)
 {
     for (byte i = 0; i < _listenerCount; i++)
     {
@@ -52,13 +52,19 @@ void EvtContext::addListener(IEvtListener *lstn)
         {
             lstn->reset();
             _listeners[i] = lstn;
-            return;
+            return true;
         }
+    }
+
+    if (_listenerCount == EVENTUALLY_MAX_LISTENERS) {
+        // do not add listener if there is no space left in _listeners
+        return false;
     }
 
     lstn->reset();
     _listeners[_listenerCount] = lstn;
     _listenerCount++;
+    return true;
 }
 
 void EvtContext::removeListener(IEvtListener *lstn)

--- a/src/EvtContext.h
+++ b/src/EvtContext.h
@@ -24,7 +24,7 @@ public:
   EvtContext(bool manageListeners = false);
   virtual void reset() override;
   virtual void loopIteration() override;
-  virtual void addListener(IEvtListener *lstn) override;
+  virtual bool addListener(IEvtListener *lstn) override;
   virtual void removeListener(IEvtListener *lstn) override;
   virtual void manageListeners(bool manage) override;
   virtual byte listenerCount() override;

--- a/src/EvtContextManager.cpp
+++ b/src/EvtContextManager.cpp
@@ -5,9 +5,9 @@ EvtContextManager::EvtContextManager()
     pushContext(&_defaultContext);
 }
 
-void EvtContextManager::addListener(IEvtListener *lstn)
+bool EvtContextManager::addListener(IEvtListener *lstn)
 {
-    currentContext()->addListener(lstn);
+    return currentContext()->addListener(lstn);
 }
 
 void EvtContextManager::removeListener(IEvtListener *lstn)

--- a/src/EvtContextManager.h
+++ b/src/EvtContextManager.h
@@ -22,7 +22,7 @@ public:
 
   virtual void reset() override;
   virtual void loopIteration() override;
-  virtual void addListener(IEvtListener *lstn) override;
+  virtual bool addListener(IEvtListener *lstn) override;
   virtual void removeListener(IEvtListener *lstn) override;
   virtual void manageListeners(bool manage) override;
   virtual byte listenerCount() override;

--- a/src/IEvtContext.h
+++ b/src/IEvtContext.h
@@ -19,7 +19,8 @@ public:
 
   /// @brief Adds a listener to the list of listeners.
   /// @param lstn
-  virtual void addListener(IEvtListener *lstn) = 0;
+  /// @return true: successful, false: failed, no space left in listerner queue
+  virtual bool addListener(IEvtListener *lstn) = 0;
 
   /// @brief Removes the listener and frees memory (using delete).
   /// Potentially introduces fragmentation of the heap so use sparingly.


### PR DESCRIPTION
do not add another listener in EvtContext::addListener() if there is no space left in the _listeners[] queue and return a result (success/failed)